### PR TITLE
Rename option functions to use 'With' prefix and make them additive

### DIFF
--- a/cob.go
+++ b/cob.go
@@ -45,6 +45,6 @@ func Run(ctx context.Context, name string, options ...option.Option[*exec.Cmd]) 
 func Output(ctx context.Context, name string, options ...option.Option[*exec.Cmd]) (*bytes.Buffer, *bytes.Buffer, *exec.Cmd, error) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	cmd, err := Run(ctx, name, append(options, AddStdouts(stdout), AddStderrs(stderr))...)
+	cmd, err := Run(ctx, name, append(options, WithStdout(stdout), WithStderr(stderr))...)
 	return stdout, stderr, cmd, err
 }

--- a/cob_test.go
+++ b/cob_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestStart(t *testing.T) {
 	output := new(bytes.Buffer)
-	cmd, err := cob.Start(context.TODO(), "echo", cob.AddArgs("Hello, World"), cob.SetStdout(output))
+	cmd, err := cob.Start(context.TODO(), "echo", cob.WithArgs("Hello, World"), cob.WithStdout(output))
 	test.MustNoError(t, err)
 	test.NoError(t, cmd.Wait())
 	test.Equal(t, output.String(), "Hello, World\n")
@@ -44,7 +44,7 @@ func TestOutput(t *testing.T) {
 			args: Args{
 				ctx:     context.TODO(),
 				name:    "echo",
-				options: option.NewOptions(cob.AddArgs("Hello, World")),
+				options: option.NewOptions(cob.WithArgs("Hello, World")),
 			},
 			expectedStdout: "Hello, World\n",
 		},
@@ -53,8 +53,8 @@ func TestOutput(t *testing.T) {
 				ctx:  context.TODO(),
 				name: "bash",
 				options: option.NewOptions(
-					cob.AddArgs("-c", `echo '$NAME' is "$NAME"`),
-					cob.AddEnv("NAME", "alice"),
+					cob.WithArgs("-c", `echo '$NAME' is "$NAME"`),
+					cob.WithEnv("NAME", "alice"),
 				),
 			},
 			expectedStdout: "$NAME is alice\n",
@@ -64,16 +64,16 @@ func TestOutput(t *testing.T) {
 				ctx:  context.TODO(),
 				name: "tr",
 				options: option.NewOptions(
-					cob.AddArgs("[:upper:]"),
-					cob.AddArgs("[:lower:]"),
-					cob.SetDir("."),
-					cob.AddEnv("KEY", "value"),
-					cob.AddStdins(strings.NewReader("hello, world")),
-					cob.AddStdouts(os.Stdout),
-					cob.AddStderrs(os.Stderr),
-					cob.AddExtraFiles(os.Stdout),
-					cob.SetSysProcAttr(&syscall.SysProcAttr{Setsid: true}),
-					cob.SetWaitDelay(time.Second),
+					cob.WithArgs("[:upper:]"),
+					cob.WithArgs("[:lower:]"),
+					cob.WithDir("."),
+					cob.WithEnv("KEY", "value"),
+					cob.WithStdin(strings.NewReader("hello, world")),
+					cob.WithStdout(os.Stdout),
+					cob.WithStderr(os.Stderr),
+					cob.WithExtraFiles(os.Stdout),
+					cob.WithSysProcAttr(&syscall.SysProcAttr{Setsid: true}),
+					cob.WithWaitDelay(time.Second),
 				),
 			},
 			expectedStdout: "hello, world",
@@ -110,11 +110,11 @@ func ExampleRun() {
 	// Hello, World
 
 	cob.Run(context.TODO(), "echo",
-		cob.AddArgs("Hello,"),
-		cob.AddArgs("World"),
-		cob.AddEnv("SHELL", "bash"),
-		cob.SetStdin(os.Stdin),
-		cob.SetStdout(os.Stdout),
+		cob.WithArgs("Hello,"),
+		cob.WithArgs("World"),
+		cob.WithEnv("SHELL", "bash"),
+		cob.WithStdin(os.Stdin),
+		cob.WithStdout(os.Stdout),
 	)
 }
 
@@ -126,17 +126,17 @@ func ExamplePipe() {
 
 	go func() {
 		cob.Run(context.TODO(), "echo",
-			cob.AddArgs("Hello, World"),
-			cob.SetStdout(pipeInput),
+			cob.WithArgs("Hello, World"),
+			cob.WithStdout(pipeInput),
 		)
 
 		pipeInput.Close()
 	}()
 
 	cob.Run(context.TODO(), "tr",
-		cob.AddArgs("[:upper:]"),
-		cob.AddArgs("[:lower:]"),
-		cob.SetStdin(pipeOutput),
-		cob.SetStdout(os.Stdout),
+		cob.WithArgs("[:upper:]"),
+		cob.WithArgs("[:lower:]"),
+		cob.WithStdin(pipeOutput),
+		cob.WithStdout(os.Stdout),
 	)
 }

--- a/options.go
+++ b/options.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strings"
 	"syscall"
 	"time"
 

--- a/options.go
+++ b/options.go
@@ -12,7 +12,7 @@ import (
 	"github.com/broothie/option"
 )
 
-// WithArgs adds arguments to the command (additive).
+// WithArgs adds arguments to the command.
 func WithArgs(args ...string) option.Func[*exec.Cmd] {
 	return func(cmd *exec.Cmd) (*exec.Cmd, error) {
 		cmd.Args = append(cmd.Args, args...)
@@ -20,18 +20,10 @@ func WithArgs(args ...string) option.Func[*exec.Cmd] {
 	}
 }
 
-// WithEnv adds environment variables to the command (additive).
-// Can be called with key-value pairs: WithEnv("KEY1", "value1", "KEY2", "value2")
-// Or with pre-formatted strings: WithEnv("KEY1=value1", "KEY2=value2")
-func WithEnv(env ...string) option.Func[*exec.Cmd] {
+// WithEnv adds an environment variable to the command.
+func WithEnv(key, value string) option.Func[*exec.Cmd] {
 	return func(cmd *exec.Cmd) (*exec.Cmd, error) {
-		// Handle key-value pairs
-		if len(env) == 2 && !strings.Contains(env[0], "=") && !strings.Contains(env[1], "=") {
-			cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", env[0], env[1]))
-		} else {
-			// Handle pre-formatted env vars
-			cmd.Env = append(cmd.Env, env...)
-		}
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 		return cmd, nil
 	}
 }
@@ -44,7 +36,7 @@ func WithDir(dir string) option.Func[*exec.Cmd] {
 	}
 }
 
-// WithStdin adds standard inputs to the command (additive using MultiReader).
+// WithStdin adds standard inputs to the command (using MultiReader).
 func WithStdin(stdins ...io.Reader) option.Func[*exec.Cmd] {
 	return func(cmd *exec.Cmd) (*exec.Cmd, error) {
 		var readers []io.Reader
@@ -57,7 +49,7 @@ func WithStdin(stdins ...io.Reader) option.Func[*exec.Cmd] {
 	}
 }
 
-// WithStdout adds standard outputs to the command (additive using MultiWriter).
+// WithStdout adds standard outputs to the command (using MultiWriter).
 func WithStdout(stdouts ...io.Writer) option.Func[*exec.Cmd] {
 	return func(cmd *exec.Cmd) (*exec.Cmd, error) {
 		var writers []io.Writer
@@ -70,7 +62,7 @@ func WithStdout(stdouts ...io.Writer) option.Func[*exec.Cmd] {
 	}
 }
 
-// WithStderr adds standard errors to the command (additive using MultiWriter).
+// WithStderr adds standard errors to the command (using MultiWriter).
 func WithStderr(stderrs ...io.Writer) option.Func[*exec.Cmd] {
 	return func(cmd *exec.Cmd) (*exec.Cmd, error) {
 		var writers []io.Writer
@@ -83,7 +75,7 @@ func WithStderr(stderrs ...io.Writer) option.Func[*exec.Cmd] {
 	}
 }
 
-// WithExtraFiles adds extra files to the command (additive).
+// WithExtraFiles adds extra files to the command.
 func WithExtraFiles(extraFiles ...*os.File) option.Func[*exec.Cmd] {
 	return func(cmd *exec.Cmd) (*exec.Cmd, error) {
 		cmd.ExtraFiles = append(cmd.ExtraFiles, extraFiles...)


### PR DESCRIPTION
Refactor the option functions to:
- Use "With" prefix instead of "Set"/"Add" pairs
- Make all functions additive (non-destructive) where possible
- Remove redundant Set/Add pairs

This PR consolidates redundant pairs and creates a cleaner, more consistent API that reduces cognitive load and follows common Go patterns.

Fixes #4

Generated with [Claude Code](https://claude.ai/code)